### PR TITLE
Made gpu-usage-by-node accept args like gpu-usage

### DIFF
--- a/gpu-usage-by-node
+++ b/gpu-usage-by-node
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-nodes=''
+nodes=`sinfo --format="%N" --noheader`
 header=false
 pretty=false
 
@@ -27,22 +27,19 @@ while getopts 'n:hHp' flag; do
   esac
 done
 
+
 if [ "$pretty" = true ]; then
   ./$0 -H -n ${nodes} | column -t -s','
   exit 0
 fi
 
-if [ "$nodes" == "" ]; then
-  nodes=`sinfo --format="%n" --noheader | sort`
-else
-  nodes=`sinfo --format="%n" --noheader -n ${nodes} | sort`
-fi
+node_list=`sinfo --format="%n" --noheader -n ${nodes} | sort`
 dt=$(date '+%d/%m/%Y %H:%M:%S');
 this_dir=$(dirname "$0")
 
 if [ "$header" = true ]; then 
   echo datetime,nodename,in_use,usable,total
 fi
-for node in $nodes; do
+for node in ${node_list}; do
   echo "${dt},${node},`${this_dir}/gpu-usage -h -n $node`"
 done 

--- a/gpu-usage-by-node
+++ b/gpu-usage-by-node
@@ -1,8 +1,48 @@
 #!/bin/bash
 
+nodes=''
+header=false
+pretty=false
+
+print_usage () {
+  cat << EOM
+Usage: $0 [-h] [-p] [-n nodelist] 
+Arguments:
+    -n    (optional) specify nodes, either comma separated list, or summarised.
+          Mirrors slurm command -n usage in sinfo, and -w usage for squeue." 
+    -H    (optional) print header (note that lowercase -h is no-header for gpu-usage)
+    -p    (optional) make output pretty, ignores -H if specified
+
+EOM
+}
+
+while getopts 'n:hHp' flag; do
+  case "${flag}" in
+    n) nodes="${OPTARG}" ;;
+    h) header=false ;;
+    H) header=true ;;
+    p) pretty=true ;;
+    *) print_usage
+       exit ;;
+  esac
+done
+
+if [ "$pretty" = true ]; then
+  ./$0 -H -n ${nodes} | column -t -s','
+  exit 0
+fi
+
+if [ "$nodes" == "" ]; then
+  nodes=`sinfo --format="%n" --noheader | sort`
+else
+  nodes=`sinfo --format="%n" --noheader -n ${nodes} | sort`
+fi
 dt=$(date '+%d/%m/%Y %H:%M:%S');
 this_dir=$(dirname "$0")
 
-for node in `sinfo --format="%n" --noheader | sort`; do
+if [ "$header" = true ]; then 
+  echo datetime,nodename,in_use,usable,total
+fi
+for node in $nodes; do
   echo "${dt},${node},`${this_dir}/gpu-usage -h -n $node`"
 done 


### PR DESCRIPTION
Now it's much easier to understand and user friendly. This would
probably be the default command people would like to run after a
simple call to gpu-usage to see if there's a queue.

Example call: 

```
 ./gpu-usage-by-node -n charles[01-07,14-16] -p
datetime             nodename   in_use  usable  total
04/04/2019 12:06:42  charles01  2       2       2
04/04/2019 12:06:42  charles02  1       2       2
04/04/2019 12:06:42  charles03  0       0       2
04/04/2019 12:06:42  charles04  2       2       2
04/04/2019 12:06:42  charles05  2       2       2
04/04/2019 12:06:42  charles06  2       2       2
04/04/2019 12:06:42  charles07  2       2       2
04/04/2019 12:06:42  charles14  3       4       4
04/04/2019 12:06:42  charles15  3       4       4
04/04/2019 12:06:42  charles16  4       4       4
```