### PR TITLE
Fix `down-gpus` and `free-gpus`, new commands, and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ source ~/.bashrc
 
 If instead of cloning the repo, you copied the files to a directory manually, make sure they are executable:
 ```{bash}
-chmod u+x {cluster-status,down-gpus,free-gpus,gpu-usage,gpu-usage-by-node,whoson} 
+chmod u+x {cluster-status,down-gpus,free-gpus,gpu-usage,gpu-usage-by-node,whoson,jobinfo,longbois,interactive,killmyjobs,onallnodes} 
 ```
 
 You should now be able to run the scripts from anywhere when on the cluster.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ You should now be able to run the scripts from anywhere when on the cluster.
 
 ## Examples
 
+* Get an interactive session
+```
+(base) [albert]s0816700: interactive
+Doing a --test-only to estimate wait time...
+srun: Job 455329 to start at 2019-05-01T14:56:10 using 1 processors on charles12
+
+Running the following command to get you an interactive session:
+srun --time=01:00:00 --mem=2000 --cpus-per-task=1 --pty bash
+
+(base) [charles12]s0816700: 
+```
+
 * Quickly identify free gpus for use
 ```
 (mg) [albert]s0816700: ./free-gpus 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
 # Useful scripts for the CDT cluster
 
-Scripts in the root directory use slurm commands and their outputs to get cluster status in a nice format.
+A collection of scripts for:
+* getting the status of the cluster: `cluster-status`, `gpu-usage`, `free-gpus`, `down-gpus`, `whoson`
+* information about running jobs: `jobinfo`, `longbois`
+* and aiding your job submission: `interactive`, `killmyjobs`, `onallnodes`
+
+They mainly just parse the output of slurm commands, so should be easy to read and understand. The [documentation for slurm](https://slurm.schedmd.com/), in particular the [man pages](https://slurm.schedmd.com/man_index.html), explain all the options.
+
+## Setup
+
+Place these scripts in a folder and add that folder to your path e.g.
+
+```{bash}
+cd ~
+mkdir git
+cd git
+git clone https://github.com/cdt-data-science/cluster-scripts.git
+echo "export PATH=/home/$USER/git/cluster-scripts:\$PATH" >> ~/.bashrc
+source ~/.bashrc
+```
+
+If instead of cloning the repo, you copied the files to a directory manually, make sure they are executable:
+```{bash}
+chmod u+x {cluster-status,down-gpus,free-gpus,gpu-usage,gpu-usage-by-node,whoson} 
+```
+
+You should now be able to run the scripts from anywhere when on the cluster.
+
 ## Examples
 
 * Quickly identify free gpus for use
@@ -55,24 +81,67 @@ s1234456  Bob smith           2
 s8765423  Joe Bloggs          1
 ```
 
+* Get information about jobs running on a node
+```
+jobinfo -n charles04
+> JobId=452332 JobName=...
+>    UserId=... GroupId=... MCS_label=N/A
+>    Priority=1027 Nice=0 Account=... QOS=normal
+>    JobState=RUNNING Reason=None Dependency=(null)
+>    Requeue=1 Restarts=0 BatchFlag=1 Reboot=0 ExitCode=0:0
+>    RunTime=9-10:22:17 TimeLimit=UNLIMITED TimeMin=N/A
+>    SubmitTime=2019-04-17T12:18:35 EligibleTime=2019-04-17T12:18:35
+>    StartTime=2019-04-17T12:18:35 EndTime=Unknown Deadline=N/A
+>    PreemptTime=None SuspendTime=None SecsPreSuspend=0
+>    LastSchedEval=2019-04-17T12:18:35
+>    Partition=cdtgpucluster AllocNode:Sid=albert:82878
+>    ReqNodeList=(null) ExcNodeList=(null)
+>    NodeList=charles04
+>    BatchHost=charles04
+>    NumNodes=1 NumCPUs=2 NumTasks=1 CPUs/Task=1 ReqB:S:C:T=0:0:*:*
+>    TRES=cpu=2,mem=14000M,node=1,billing=2,gres/gpu=1
+>    Socks/Node=* NtasksPerN:B:S:C=0:0:*:* CoreSpec=*
+>    MinCPUsNode=1 MinMemoryNode=14000M MinTmpDiskNode=0
+>    Features=(null) DelayBoot=00:00:00
+>    Gres=gpu:1 Reservation=(null)
+>    OverSubscribe=OK Contiguous=0 Licenses=(null) Network=(null)
+>    Command=...
+>    WorkDir=...
+>    StdErr=...
+>    StdIn=/dev/null
+>    StdOut=...
+>    Power=
+```
+
+* Kill all your jobs
+```
+# Launch some jobs
+some_script=/mnt/cdtds_cluster_home/s0816700/git/melody_gen/scripts/slurm_blankjob.sh
+for ii in {1..8}; do 
+  sbatch --time=05:00 --nodelist=charles01 --cpus-per-task=8 --mem=2000 $some_script 100
+done
+```
+
+```
+# Kill em
+killmyjobs
+> killing jobs in queue as well as running jobs
+> killing 454218 454219 454220 454221 454214 454215 454216 454217
+```
+
+or
+
+```
+# Only kill ones running (leave ones in queue alone)
+killmyjobs -g
+> not killing jobs in queue
+> killing 454206 454207 454208 454209
+```
+
+* Run a job on every node in the cluseter - useful for something like changing data on scratch spaces
+```
+some_script=/mnt/cdtds_cluster_home/s0816700/git/melody_gen/scripts/slurm_diskspace.sh
+onallnodes $some_script
+```
+
 The scripts in the gridengine directory are from the previous scheduler sytem, and won't work with SLURM.
-
-## Setup
-
-Place these scripts in a folder and add that folder to your path e.g.
-
-```{bash}
-cd ~
-mkdir git
-cd git
-git clone https://github.com/cdt-data-science/cluster-scripts.git
-echo "export PATH=/home/$USER/git/cluster-scripts:\$PATH" >> ~/.bashrc
-source ~/.bashrc
-```
-
-If instead of cloning the repo, you copied the files to a directory manually, make sure they are executable:
-```{bash}
-chmod u+x {cluster-status,down-gpus,free-gpus,gpu-usage,gpu-usage-by-node,whoson} 
-```
-
-You should now be able to run the scripts from anywhere when on the cluster.

--- a/cluster-status
+++ b/cluster-status
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sinfo -o "%N,%G,%T,%H,%E,%e/%m,%O" -N | column -t -s','
+sinfo -o "%N,%G,%T,%H,%E,%e/%m,%C,%O" -N | column -t -s','
 

--- a/down-gpus
+++ b/down-gpus
@@ -1,8 +1,9 @@
 #!/bin/bash
 relative_dir=`dirname $0`
 down_gpus=''
+full_capacity=`${relative_dir}/gpu-usage -h | awk -F',' '{if ($2 == $3) printf("true"); else printf("false")}'`
 down_gpus=`${relative_dir}/gpu-usage-by-node -p | awk 'NR==1 {print $0} NR > 1 {if ($6 > $5) print $0}'`
-if [ "${down_gpus}" == "" ]; then
+if $full_capacity; then
   echo 'All up!'
 else
   echo "${down_gpus}"

--- a/free-gpus
+++ b/free-gpus
@@ -1,12 +1,12 @@
 #!/bin/bash
 relative_dir=`dirname $0`
-free_gpus=''
+full_capacity=`${relative_dir}/gpu-usage -h | awk -F',' '{if ($1 == $2) printf("true"); else printf("false")}'`
 free_gpus=`${relative_dir}/gpu-usage-by-node -p | awk 'NR==1 {print $0} NR > 1 {if ($5 > $4) print $0}'`
-if [ "${free_gpus}" == "" ]; then
+if $full_capacity; then
   echo No gpus free...join the squeue!
   echo "Tip: you can use the command sprio to observe your job's priority"
   echo "Current queue:"
-  sprio
+  sprio -l
 else
   echo "${free_gpus}"
 fi

--- a/interactive
+++ b/interactive
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+default_args="--time=01:00:00 --mem=2000 --cpus-per-task=1"
+read -r -d '' default_msg << EOM
+======================= WELCOME MESSAGE =======================
+It's good practice to set a few parameters when using srun
+(this command is essentailly an alias for 'srun --pty bash').
+We have added some default parameters to maximise your chance
+of getting an interactive session. See the Slurm Documentation
+for further info.
+
+https://slurm.schedmd.com/
+
+Default args added:
+[$default_args]
+
+Useful arg examples:
+* --time=08:00:00        terminate job after 8 hours (good
+                         practice and curteous)
+* --time=1-04:00:30      terminate job after 1 day, 4 hours,
+                         and 30 seconds
+* --gres=gpu:1           give me 1 gpu
+* --nodelist=charles19   put me on a specific node
+* --mem=4000             give me 4G of RAM, there's about 50G
+                         per box but memory is not shared 
+                         (note this is not GPU memory)
+* --cpus-per-task=1      give me 1 cpu, there's 32 on most
+                         nodes
+
+For more informtion about node configuration, see the
+computing support docs:
+http://computing.help.inf.ed.ac.uk/james-and-charles-cluster
+
+
+When you run this command with args, this message will
+disappear, and no additional args will be added.
+===============================================================
+EOM
+
+print_usage () {
+  cat << EOM
+Usage: $0 [other args for srun] 
+
+Arguments:
+    see documentation for srun. You can specify all arguments, and they'll
+    be used.
+EOM
+}
+
+if [ $# -eq 0 ]; then
+    echo "$default_msg"
+    args=$default_args
+else
+    args=$@
+fi
+
+echo
+echo Doing a --test-only to estimate wait time...
+srun $args --test-only --pty bash
+echo
+
+echo Running the following command to get you an interactive session:
+echo "srun $args --pty bash"
+echo ...
+srun $args --pty bash

--- a/jobinfo
+++ b/jobinfo
@@ -4,12 +4,12 @@ nodes=`sinfo --format="%N" --noheader`
 
 print_usage () {
   cat << EOM
-Usage: $0 [-n charles[01-19]]
+Usage: $0 [-n charles[01-19]] [-u username]
     Get information about all jobs on specified nodes (defaults to all jobs)
 Arguments
     -n    (optional) specify nodes, either comma separated list, or summarised.
-          Mirrors slurm command -n usage in sinfo, and -w usage for squeue." 
- 
+          Mirrors slurm command -n usage in sinfo, and -w usage for squeue. 
+    -u    (optional) specify a user 
 EOM
 }
 

--- a/jobinfo
+++ b/jobinfo
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+nodes=`sinfo --format="%N" --noheader`
+
+print_usage () {
+  cat << EOM
+Usage: $0 [-n charles[01-19]]
+    Get information about all jobs on specified nodes (defaults to all jobs)
+Arguments
+    -n    (optional) specify nodes, either comma separated list, or summarised.
+          Mirrors slurm command -n usage in sinfo, and -w usage for squeue." 
+ 
+EOM
+}
+
+while getopts 'n:u:' flag; do
+  case "${flag}" in
+    n) nodes="${OPTARG}" ;;
+    u) user="${OPTARG}" ;;
+    *) print_usage
+       exit ;;
+  esac
+done
+
+if [ -n "${user}" ]; then
+    user_arg="--user=${user}"
+else
+    user_arg=""
+fi
+squeue --nodelist=${nodes} -o"%i" --noheader ${user_arg} | xargs -I {} sh -c 'scontrol show JobId={}'

--- a/killmyjobs
+++ b/killmyjobs
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+running_only=false
+
+print_usage () {
+  cat << EOM
+Usage: $0 [-n nodelist] [-g] 
+    Kills all your jobs! By default, also kills those you have queued up too.
+    To only kill your running jobs, use the -g flag.
+
+Arguments:
+script    the script to be submitted to slurm via sbatch
+    -n    (optional) specify nodes, either comma separated list, or summarised.
+          Mirrors slurm command -n usage in sinfo, and -w usage for squeue." 
+EOM
+}
+
+while getopts 'n:g' flag; do
+  case "${flag}" in
+    n) nodes="${OPTARG}" ;;
+    g) running_only=true ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+if [ "$running_only" = true ]; then
+    if [ -z ${nodes+x} ]; then
+        nodes=`sinfo --format="%N" --noheader`
+    fi
+    echo not killing jobs in queue
+    jobids="$(squeue -u `whoami` --nodelist=${nodes} -o "%i" --noheader)"
+else
+    echo killing jobs in queue as well as running jobs
+    jobids="$(squeue -u `whoami` -o "%i" --noheader)"
+fi
+if [ "${jobids}" = "" ]; then
+    echo "well I would...but you've got no jobs to kill m8"
+else
+    echo killing $jobids
+    parallel 'scancel {}' ::: ${jobids} 
+fi

--- a/killmyjobs
+++ b/killmyjobs
@@ -9,9 +9,9 @@ Usage: $0 [-n nodelist] [-g]
     To only kill your running jobs, use the -g flag.
 
 Arguments:
-script    the script to be submitted to slurm via sbatch
     -n    (optional) specify nodes, either comma separated list, or summarised.
           Mirrors slurm command -n usage in sinfo, and -w usage for squeue." 
+    -g    (optional) will only kill running jobs, not jobs in the queue 
 EOM
 }
 

--- a/longbois
+++ b/longbois
@@ -1,0 +1,9 @@
+# Prints details of interactive jobs running for longer than a day
+# This is prob better for getting interactive jobs but grep for bash works
+# squeue --Format="jobid,batchflag" | awk 'NR>1 {if ($2==0) print $1}'
+squeue --name=bash |  # Select interactive jobs by assuming jobname is bash
+    grep - |  # Select only jobs running longer than a day
+    awk '{ print $1 }' |  # Get the jobids
+    cut -c1-6 | sort | uniq |  # Get unique list (and handle arrayjobs)
+    xargs -I {} sh -c 'scontrol show JobId={}'  # get all info about each job
+

--- a/onallnodes
+++ b/onallnodes
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+nodes=`sinfo --format="%N" --noheader`
+
+print_usage () {
+  cat << EOM
+Runs given script on all nodes by submitting supplied script with sbatch
+
+Usage: $0 [-n nodelist] script 
+Arguments:
+script    the script to be submitted to slurm via sbatch
+    -n    (optional) specify nodes, either comma separated list, or summarised.
+          Mirrors slurm command -n usage in sinfo, and -w usage for squeue." 
+EOM
+}
+
+while getopts 'n:' flag; do
+  case "${flag}" in
+    n) nodes="${OPTARG}" ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+script="${@:$OPTIND:1}"
+if [ "$script" = "" ]; then
+    >&2 echo "You must supply a script"
+    exit 1
+fi
+
+node_list=`sinfo --format="%n" --noheader -n ${nodes} | sort`
+
+parallel "sbatch --nodelist={} ${script}" ::: $node_list
+


### PR DESCRIPTION
Headline new command is a `interactive`, which gets you a quick interactive session (and provides info for new users).

Other new commands:
* `onallnodes` - will run the supplied script on all nodes. Very handy for doing data admin e.g. deleting files.
* `killmyjobs` - will kill all your running jobs
* `jobinfo` - get information about running jobs by user or nodes

Existing commands `down-gpus` and `free-gpus` had a little :bug:: if the cluster was at capacity then they would not work as intended (the if statements were wrong).