### PR TITLE
feat: Add job ID autocompletion for scancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ chmod u+x {cluster-status,down-gpus,free-gpus,gpu-usage,gpu-usage-by-node,whoson
 
 You should now be able to run the scripts from anywhere when on the cluster.
 
+If you want to have job ID autocompletion for `scancel`, you need to source the `job-id-completion.sh` script:
+
+```{bash}
+cd ~
+echo "source /home/$USER/git/cluster-scripts/job-id-completion.sh" >> ~/.bashrc
+source ~/.bashrc
+```
+
 ## Examples
 
 * Get an interactive session

--- a/job-id-completion.sh
+++ b/job-id-completion.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+_cluster_jobs()
+{
+    # Based on tutorial at:
+    # https://iridakos.com/tutorials/2018/03/01/bash-programmable-completion-tutorial.html
+
+    local cur prev base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # redefine field separator to preserve whitespace
+    local IFS=$'\n'
+   
+    # Get Job numbers and names
+    local job_ids=$(squeue --user ${USER} -o "%A (%j)" --noheader)
+
+    # Filter based on what user hasd typed
+    local suggestions=( $(compgen -W "${job_ids}" -- ${cur}) )
+
+    if [ "${#suggestions[@]}" == "1" ]; then
+        # if there's only one match, we remove the command literal
+        # to proceed with the automatic completion of the number
+        local number=$(echo ${suggestions[0]/%\ */})
+        COMPREPLY=("$number")
+    else
+        # more than one suggestions resolved,
+        # respond with the suggestions intact
+        COMPREPLY=("${suggestions[@]}")
+    fi
+
+    return 0
+}
+
+complete -F _cluster_jobs scancel


### PR DESCRIPTION
Adds a script that will enable tab key autocompletion for `scancel`.
Pressing <tab> key after `scancel` will give a list of your job IDs and names.
Entering the start of a job ID and pressing <tab> will autocomplete the ID if it is unique.

To enable this, need to source the script in your `.bashrc` file

Example:
```{bash}
$  scancel <tab>
41 (job_name_1)  83 (job_name_2)
```