### PR TITLE
Better array handling

### DIFF
--- a/killmyjobs
+++ b/killmyjobs
@@ -32,7 +32,7 @@ if [ "$running_only" = true ]; then
     jobids="$(squeue -u `whoami` --nodelist=${nodes} -o "%i" --noheader)"
 else
     echo killing jobs in queue as well as running jobs
-    jobids="$(squeue -u `whoami` -o "%i" --noheader)"
+    jobids="$(squeue -r -u `whoami` -o "%i" --noheader)"
 fi
 if [ "${jobids}" = "" ]; then
     echo "well I would...but you've got no jobs to kill m8"

--- a/whoson
+++ b/whoson
@@ -19,7 +19,7 @@ while getopts ':g' flag; do
   esac
 done
 
-squeue --noheader -o "%u %T %b" | sort | awk -v countgpus="${gpu}" '
+squeue -r --noheader -o "%u %T %b" | sort | awk -v countgpus="${gpu}" '
 BEGIN{
     printf "sid,name,jobs(running/pending/total)\n";
     previd="";

--- a/whoson
+++ b/whoson
@@ -19,61 +19,21 @@ while getopts ':g' flag; do
   esac
 done
 
-if [ "${gpu}" == false ]; then
-	squeue --noheader -o "%u %T" | sort | uniq -c | awk '
+squeue --noheader -o "%u %T %b" | sort | awk -v countgpus="${gpu}" '
 BEGIN{
     printf "sid,name,jobs(running/pending/total)\n";
     previd="";
     pending_count=0;
     running_count=0;
 } {
-    if (NR==1) 
+    if (countgpus=="true")
     {
-	previd=$2;
+        sub(/.*:/, "",$3)
     }
-    if ($2==previd) 
-    { 
-        if ($3=="PENDING")
-        {
-            pending_count=$1
-        }
-        else if ($3=="RUNNING")
-        {
-            running_count=$1
-        }
-    } 
-    else 
+    else
     {
-	cmd="finger -s \""previd"\" | awk '\'' NR > 1 {print $2, $3} '\'' ";
-	cmd|getline name; 
-        printf "%s,%s,%s/%s/%s\n", previd, name, running_count,pending_count,running_count+pending_count; 
-        running_count=0;
-        pending_count=0;
-        previd=$2;
-	if ($3=="PENDING")
-        {
-            pending_count=$1
-        }
-	else if ($3=="RUNNING")
-        {
-            running_count=$1
-        }
-
+        $3 = 1
     }
-    close(cmd)
-}END{
-    cmd="finger -s \""$2"\" | awk '\'' NR > 1 {print $2, $3} '\'' ";
-    cmd|getline name;
-    printf "%s,%s,%s/%s/%s\n", $2, name, running_count,pending_count,running_count+pending_count}' | column -s',' -t
-else
-        squeue --noheader -o "%u %T %b" | sort | awk '
-BEGIN{
-    printf "sid,name,jobs(running/pending/total)\n";
-    previd="";
-    pending_count=0;
-    running_count=0;
-} {
-    sub(/.*:/, "",$3)
     if (NR==1)
     {
      	previd=$1;
@@ -112,5 +72,3 @@ BEGIN{
     cmd="finger -s \""$1"\" | awk '\'' NR > 1 {print $2, $3} '\'' ";
     cmd|getline name;
     printf "%s,%s,%s/%s/%s\n", $1, name, running_count,pending_count,running_count+pending_count}' | column -s',' -t
-	
-fi


### PR DESCRIPTION
Doing `squeue -r` puts pending array jobs on separate lines, giving a more accurate count of the number of jobs pending. 

I've made the change for `whoson`, are there any other scripts where this matters?