### PR TITLE
fix: Stop always printing help message

### DIFF
--- a/down-gpus
+++ b/down-gpus
@@ -14,7 +14,7 @@ Output:
 EOM
 }
 
-if [ ${#@} -lt 0 ]; then
+if [ ${#@} -gt 0 ]; then
     print_usage
     exit
 fi

--- a/down-gpus
+++ b/down-gpus
@@ -14,7 +14,7 @@ Output:
 EOM
 }
 
-if [ ${#@} > 0 ]; then
+if [ ${#@} -lt 0 ]; then
     print_usage
     exit
 fi

--- a/free-gpus
+++ b/free-gpus
@@ -23,7 +23,8 @@ Output:
 EOM
 }
 
-if [ ${#@} > 0 ]; then
+if [ "${#@}" -gt 0 ]; then
+    echo "${#@}"
     print_usage
     exit
 fi

--- a/free-gpus
+++ b/free-gpus
@@ -23,7 +23,7 @@ Output:
 EOM
 }
 
-if [ "${#@}" -gt 0 ]; then
+if [ ${#@} -gt 0 ]; then
     echo "${#@}"
     print_usage
     exit


### PR DESCRIPTION
Fix the bugs in `free-gpus` and `down-gpus` introduced in #17 (they always print the help messages instead of running).