### PR TITLE
Show free gpus

### DIFF
--- a/free-gpus
+++ b/free-gpus
@@ -31,7 +31,7 @@ fi
 
 relative_dir=`dirname $0`
 full_capacity=`${relative_dir}/gpu-usage -h | awk -F',' '{if ($1 == $2) printf("true"); else printf("false")}'`
-free_gpus=`${relative_dir}/gpu-usage-by-node -p | awk 'NR==1 {print $1,$2,$6} NR > 1 {if ($7 > 0) print $1,$2,$3,$7}' | column -t -s','`
+free_gpus=`${relative_dir}/gpu-usage-by-node -p | awk 'NR==1 {printf "%s,%s,%s\n",$1,$2,$6} NR > 1 {if ($7 > 0) printf "%s %s,%s,%s\n",$1,$2,$3,$7}' | column -t -s','`
 if $full_capacity; then
   echo "No gpus free...join the squeue!"
   echo "Tip: you can use the command sprio to observe your job's priority"

--- a/free-gpus
+++ b/free-gpus
@@ -31,7 +31,7 @@ fi
 
 relative_dir=`dirname $0`
 full_capacity=`${relative_dir}/gpu-usage -h | awk -F',' '{if ($1 == $2) printf("true"); else printf("false")}'`
-free_gpus=`${relative_dir}/gpu-usage-by-node -p | awk 'NR==1 {print $0} NR > 1 {if ($5 > $4) print $0}'`
+free_gpus=`${relative_dir}/gpu-usage-by-node -p | awk 'NR==1 {print $1,$2,$6} NR > 1 {if ($7 > 0) print $1,$2,$3,$7}' | column -t -s','`
 if $full_capacity; then
   echo "No gpus free...join the squeue!"
   echo "Tip: you can use the command sprio to observe your job's priority"

--- a/gpu-usage
+++ b/gpu-usage
@@ -87,7 +87,7 @@ if [ "$TOTAL" == '' ]; then
 fi
 
 # Get number of free GPUs
-FREE=$(expr "${USABLE} - ${USED}")
+FREE=$(expr "${USABLE}" - "${USED}")
 
 if [ "$header" = true ]; then 
   echo "in_use,usable,total,free"

--- a/gpu-usage
+++ b/gpu-usage
@@ -86,7 +86,10 @@ if [ "$TOTAL" == '' ]; then
   TOTAL=0
 fi
 
+# Get number of free GPUs
+FREE=$(expr "${USABLE} - ${USED}")
+
 if [ "$header" = true ]; then 
-  echo "in_use,usable,total"
+  echo "in_use,usable,total,free"
 fi
-echo "${USED},${USABLE},${TOTAL}"
+echo "${USED},${USABLE},${TOTAL},${FREE}"

--- a/gpu-usage-by-node
+++ b/gpu-usage-by-node
@@ -54,7 +54,7 @@ dt=$(date '+%d/%m/%Y %H:%M:%S');
 this_dir=$(dirname "$0")
 
 if [ "$header" = true ]; then 
-  echo datetime,nodename,in_use,usable,total
+  echo "datetime,nodename,in_use,usable,total,free"
 fi
 for node in ${node_list}; do
   echo "${dt},${node},`${this_dir}/gpu-usage -h -n $node`"


### PR DESCRIPTION
`gpu-usage` now returns a fourth column "free gpus", which is the difference between "usable" and "in_use".

`free-gpus` now only returns the "free gpus" column.

Hopefully adding the fourth column doesn't mess up your logging scripts too much.