### PR TITLE
Add option to specify partitions for onallnodes

### DIFF
--- a/onallnodes
+++ b/onallnodes
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 nodes=`sinfo --format="%N" --noheader`
+partitions=`sinfo --format="%R" --noheader | tr '\n' ','`
 
 print_usage () {
   cat << EOM
@@ -10,14 +11,16 @@ Usage: $0 [-n nodelist] script
 Arguments:
     script    the script to be submitted to slurm via sbatch
     -n        (optional) specify nodes, either comma separated list, or summarised.
-              Mirrors slurm command -n usage in sinfo, and -w usage for squeue."
+              Mirrors slurm command -n usage in sinfo, and -w usage for squeue.
+    -p        (optional) specify partitions, comma separated."
 
 EOM
 }
 
-while getopts 'n:' flag; do
+while getopts 'n:p:' flag; do
   case "${flag}" in
     n) nodes="${OPTARG}" ;;
+    p) partitions="${OPTARG}" ;;
     *) print_usage
        exit 1 ;;
   esac
@@ -30,9 +33,10 @@ if [ "$script" = "" ]; then
     exit 1
 fi
 
-node_partition_list=`sinfo --format="%n,%R" --noheader -n ${nodes} -N`
+node_partition_list=`sinfo --format="%n,%R" --noheader -n ${nodes} -p ${partitions} -N`
+nodes_filtered=`sinfo --format="%N" --noheader -n ${nodes} -p ${partitions}`
 node=`echo "${node_partition_list}" | cut -f1 -d','` 
 partition=`echo "${node_partition_list}" | cut -f2 -d','` 
-echo "running $script on nodes $nodes"
+echo "running $script on nodes $nodes_filtered"
 parallel --link "sbatch --partition={1} --nodelist={2} ${script}" ::: $partition ::: $node 
 


### PR DESCRIPTION
Use `-p` to specify a list of partitions to run a script on.